### PR TITLE
Update popup.js: fix styling issues

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -13,7 +13,7 @@ focuss.onclick = function(element) {
     chrome.tabs.executeScript(
         tabs[0].id,
         {code: 
-		  "document.getElementsByClassName('ya-Toolbar')[0].style.display = 'block'; var x = document.getElementsByClassName('top-panel-container'); var i; for (i = 0; i < x.length; i++) { x[i].style.display = 'none';}"
+		  "document.getElementsByClassName('ya-Toolbar')[0].style.display = 'inline-table'; var x = document.getElementsByClassName('top-panel-container'); var i; for (i = 0; i < x.length; i++) { x[i].style.display = 'none';}"
 
 		});
 	});
@@ -24,7 +24,7 @@ focusss.onclick = function(element) {
     chrome.tabs.executeScript(
         tabs[0].id,
         {code: 
-		  "document.getElementsByClassName('ya-Toolbar')[0].style.display = 'block'; var x = document.getElementsByClassName('top-panel-container'); var i; for (i = 0; i < x.length; i++) { x[i].style.display = 'block';}"
+		  "document.getElementsByClassName('ya-Toolbar')[0].style.display = 'inline-table'; var x = document.getElementsByClassName('top-panel-container'); var i; for (i = 0; i < x.length; i++) { x[i].style.display = 'inline-table';}"
 
 		});
 	});


### PR DESCRIPTION
When, in the old code, the layout was reset using the "DEFAULT" button, the toolbars shrinked and turned out weird, because they was set to `display:block`. This is a quick and little fix. It is already implemented in the Firefox extension.

**Before the patch**:
![image](https://user-images.githubusercontent.com/41679054/57182977-a72ecf00-6ea6-11e9-9356-aa8e11b7f3f8.png)

**After the patch**:
![image](https://user-images.githubusercontent.com/41679054/57182988-c2014380-6ea6-11e9-96c8-02fdc0dcf574.png)

Review requested from @yusufcihan, because he is the maintainer of the Chrome/Chromium extension